### PR TITLE
Add unit tests and .NET project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Visual Studio and .NET build artifacts
+bin/
+obj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+
+# Build results
+x64/
+x86/
+
+# Rider
+.idea/
+
+# Others
+*.log

--- a/DataAnalysis.Tests/CsvAnalyzerTests.cs
+++ b/DataAnalysis.Tests/CsvAnalyzerTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using DataAnalysis;
+
+namespace DataAnalysis.Tests;
+
+public class CsvAnalyzerTests
+{
+    [Fact]
+    public void Analyze_ComputesExpectedStatistics()
+    {
+        string csv = "A,B\n1,2\n4,5\n7,8\n";
+        string path = Path.GetTempFileName();
+        File.WriteAllText(path, csv);
+
+        var analyzer = new CsvAnalyzer();
+        analyzer.Load(path);
+        var results = analyzer.Analyze();
+
+        Assert.Equal(2, results.Count);
+
+        var col1 = results[0];
+        Assert.Equal(4, col1.Mean, 5);
+        Assert.Equal(4, col1.Median, 5);
+        Assert.Equal(3, col1.StandardDeviation, 5);
+        Assert.Equal(1, col1.Min, 5);
+        Assert.Equal(7, col1.Max, 5);
+
+        var col2 = results[1];
+        Assert.Equal(5, col2.Mean, 5);
+        Assert.Equal(5, col2.Median, 5);
+        Assert.Equal(3, col2.StandardDeviation, 5);
+        Assert.Equal(2, col2.Min, 5);
+        Assert.Equal(8, col2.Max, 5);
+    }
+
+    [Fact]
+    public void Load_Throws_OnEmptyFile()
+    {
+        string path = Path.GetTempFileName();
+        File.WriteAllText(path, string.Empty);
+        var analyzer = new CsvAnalyzer();
+        Assert.Throws<Exception>(() => analyzer.Load(path));
+    }
+
+    [Fact]
+    public void Load_IgnoresNonNumericValues()
+    {
+        string csv = "A\n1\ntext\n4\n";
+        string path = Path.GetTempFileName();
+        File.WriteAllText(path, csv);
+
+        var analyzer = new CsvAnalyzer();
+        analyzer.Load(path);
+        var results = analyzer.Analyze();
+
+        Assert.Single(results);
+        var stats = results[0];
+        Assert.Equal(2.5, stats.Mean, 5);
+        Assert.Equal(2.5, stats.Median, 5);
+        Assert.Equal(Math.Sqrt(4.5), stats.StandardDeviation, 5);
+        Assert.Equal(1, stats.Min, 5);
+        Assert.Equal(4, stats.Max, 5);
+    }
+}

--- a/DataAnalysis.Tests/DataAnalysis.Tests.csproj
+++ b/DataAnalysis.Tests/DataAnalysis.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DataAnalysis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DataAnalysis.Tests/GlobalUsings.cs
+++ b/DataAnalysis.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/DataAnalysis.csproj
+++ b/DataAnalysis.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DataAnalysis.cs" />
+  </ItemGroup>
+</Project>

--- a/DataAnalysis.sln
+++ b/DataAnalysis.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataAnalysis", "DataAnalysis.csproj", "{07C14BC7-BB4C-4AE9-8F6F-60E90DB9CE94}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataAnalysis.Tests", "DataAnalysis.Tests\DataAnalysis.Tests.csproj", "{AF5B5122-52E2-46A6-A18C-327F523A8CEA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{07C14BC7-BB4C-4AE9-8F6F-60E90DB9CE94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07C14BC7-BB4C-4AE9-8F6F-60E90DB9CE94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07C14BC7-BB4C-4AE9-8F6F-60E90DB9CE94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07C14BC7-BB4C-4AE9-8F6F-60E90DB9CE94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF5B5122-52E2-46A6-A18C-327F523A8CEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF5B5122-52E2-46A6-A18C-327F523A8CEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF5B5122-52E2-46A6-A18C-327F523A8CEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF5B5122-52E2-46A6-A18C-327F523A8CEA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ the program prints:
 Column 1:
   Mean = 4.0000
   Median = 4.0000
-  Std Dev = 2.4495
+  Std Dev = 3.0000
   Min = 1.0000
   Max = 7.0000
 ...


### PR DESCRIPTION
## Summary
- add .NET project and solution files
- add xUnit test project with coverage for stats, empty files and non-numeric values
- correct README standard deviation example

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689a09e49a28832c82a8c50523edd3b9